### PR TITLE
Support for Team Drive

### DIFF
--- a/docshare.go
+++ b/docshare.go
@@ -16,17 +16,24 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
+	"time"
 )
 
 const (
 	usage          = "usage: docshare [-n] (-a|-r email-addr) doc-id [doc-id...]"
 	maxConcurrency = 10
+	driveAPI       = "https://www.googleapis.com/drive/v3"
 )
 
 var (
@@ -35,11 +42,8 @@ var (
 	remUser    = flag.String("r", "", "email addr of user to remove")
 )
 
-type permission struct {
-	Role         string `json:"role"`
-	Type         string `json:"type"`
-	EmailAddress string `json:"emailAddress"`
-}
+// errNotFound is an internal error indicating a missing resource.
+var errNotFound = errors.New("resource not found")
 
 // docshare - add and/or remove sharing permissions on one or more Google Docs.
 func main() {
@@ -62,7 +66,10 @@ func main() {
 		if err != nil {
 			log.Fatalf("error marshaling body: %v", err)
 		}
-		notifyParam := fmt.Sprintf("sendNotificationEmail=%v", *notifyFlag)
+		params := url.Values{
+			"sendNotificationEmail": {fmt.Sprintf("%v", *notifyFlag)},
+			"supportsTeamDrives":    {"true"},
+		}
 		for _, id := range flag.Args()[0:] {
 			ch <- struct{}{}
 			wg.Add(1)
@@ -71,7 +78,7 @@ func main() {
 					<-ch
 					wg.Done()
 				}()
-				url := fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s/permissions?%s", id, notifyParam)
+				url := fmt.Sprintf("%s/files/%s/permissions?%s", driveAPI, id, params.Encode())
 				resp, err := client.Post(url, "application/json", bytes.NewReader(body))
 				if err != nil {
 					log.Printf("error posting to %s for doc %s: %v (%v)", url, id, err, resp.StatusCode)
@@ -79,7 +86,7 @@ func main() {
 				}
 				defer resp.Body.Close()
 				if resp.StatusCode != 200 {
-					log.Printf("error posting to %s for doc %s: %v", url, id, resp.StatusCode)
+					log.Printf("%s: %v", id, errorResponse(resp))
 				}
 			}(id, body)
 		}
@@ -89,59 +96,115 @@ func main() {
 			ch <- struct{}{}
 			wg.Add(1)
 			go func(docID string) {
+				// TODO: figure out a better way to create context for each goroutine.
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 				defer func() {
+					cancel()
 					<-ch
 					wg.Done()
 				}()
-				url := fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s/permissions?fields=permissions(emailAddress%%2Cid)", docID)
-				resp, err := client.Get(url)
+				p, err := fetchPermission(ctx, client, docID, *remUser, pageToken(""))
+				if err == errNotFound {
+					// Already removed. Nothing to do.
+					return
+				}
 				if err != nil {
-					log.Printf("error getting perms via %s for doc %s: %v (%v)", url, docID, err, resp.StatusCode)
+					log.Printf("%s: %v", docID, err)
 					return
 				}
-				defer resp.Body.Close()
-				if resp.StatusCode != 200 {
-					log.Printf("error getting perms via %s for doc %s: %v (%v)", url, docID, err, resp.StatusCode)
-					return
-				}
-				var p struct {
-					Permissions []*struct {
-						ID           string `json:"id"`
-						EmailAddress string `json:"emailAddress"`
-					}
-				}
-				if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
-					log.Printf("error parsing resp body from %s for doc %s", url, docID)
-					return
-				}
-				var permID string
-				for _, v := range p.Permissions {
-					if v.EmailAddress == *remUser {
-						permID = v.ID
-						break
-					}
-				}
-				if permID == "" {
-					log.Printf("specified email addr (%s) not shared with doc %s", *remUser, docID)
-					return
-				}
-				url = fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s/permissions/%s", docID, permID)
-				req, err := http.NewRequest("DELETE", url, nil)
+				u := fmt.Sprintf("%s/files/%s/permissions/%s?supportsTeamDrives=true", driveAPI, docID, p.ID)
+				req, err := http.NewRequest("DELETE", u, nil)
 				if err != nil {
-					log.Printf("error building delete req %s for doc %s: %v", url, docID, err)
+					log.Printf("error building delete req %s for doc %s: %v", u, docID, err)
 					return
 				}
-				resp, err = client.Do(req)
+				resp, err := client.Do(req.WithContext(ctx))
 				if err != nil {
-					log.Printf("error deleting perm %s for doc %s: %v (%v)", url, docID, err, resp.StatusCode)
+					log.Printf("error deleting perm %s for doc %s: %v (%v)", u, docID, err, resp.StatusCode)
 					return
 				}
 				defer resp.Body.Close()
 				if resp.StatusCode != 200 && resp.StatusCode != 204 {
-					log.Printf("error deleting perm %s for doc %s: %v", url, docID, resp.StatusCode)
+					log.Printf("%s: %v", docID, errorResponse(resp))
 				}
 			}(id)
 		}
 	}
 	wg.Wait()
+}
+
+type pageToken string
+
+func (t pageToken) zero() bool {
+	return t == ""
+}
+
+type permission struct {
+	ID           string `json:"id,omitempty"`
+	Role         string `json:"role"`
+	Type         string `json:"type"`
+	EmailAddress string `json:"emailAddress"`
+}
+
+func fetchPermission(ctx context.Context, client *http.Client, docID, email string, token pageToken) (*permission, error) {
+	params := url.Values{
+		"supportsTeamDrives": {"true"},
+		"pageSize":           {"10"},
+		"fields":             {"nextPageToken,permissions(id,emailAddress)"},
+	}
+	if !token.zero() {
+		params.Set("pageToken", string(token))
+	}
+	r, err := http.NewRequest("GET", fmt.Sprintf("%s/files/%s/permissions?%s", driveAPI, docID, params.Encode()), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(r.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, errorResponse(resp)
+	}
+	var p struct {
+		NextPageToken string
+		Permissions   []*permission
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		return nil, err
+	}
+	for _, v := range p.Permissions {
+		if v.EmailAddress == email {
+			if v.ID == "" {
+				return nil, fmt.Errorf("no permission ID for %s", email)
+			}
+			return v, nil
+		}
+	}
+	if len(p.Permissions) == 0 || p.NextPageToken == "" {
+		return nil, errNotFound
+	}
+	return fetchPermission(ctx, client, docID, email, pageToken(p.NextPageToken))
+}
+
+func errorResponse(res *http.Response) error {
+	var e struct {
+		Error struct {
+			Errors []struct{ Message string }
+		}
+	}
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return errors.New(res.Status)
+	}
+	err = json.Unmarshal(b, &e)
+	if err != nil || len(e.Error.Errors) == 0 {
+		return fmt.Errorf("%s: %s", res.Status, b)
+	}
+	var a []string
+	for _, v := range e.Error.Errors {
+		a = append(a, v.Message)
+	}
+	return errors.New(strings.Join(a, "; "))
 }


### PR DESCRIPTION
See details at the API docs page:
https://developers.google.com/drive/v3/web/enable-teamdrives

This also adds a nicer error message. For instance, instead of 403
or 404 code, the program displays the actual error message
as sent from Drive.

R: @marcacohen 